### PR TITLE
feat: Add a delay option for optimistic rendering situations

### DIFF
--- a/example.es6
+++ b/example.es6
@@ -10,5 +10,7 @@ export default (
       Just a test that is overlayed by the loader
       <Loading loadingText="We are loading something..." className="loading--overlay" />
     </div>
+    <p>With 2 seconds of delay</p>
+    <Loading delay={2000} />
   </div>
 );

--- a/index.es6
+++ b/index.es6
@@ -1,4 +1,6 @@
 import React from 'react';
+import Delay from 'react-delay';
+
 /* eslint-disable func-style */
 export default class Loading extends React.Component {
 
@@ -7,6 +9,7 @@ export default class Loading extends React.Component {
       className: React.PropTypes.string,
       overlay: React.PropTypes.bool,
       loadingText: React.PropTypes.string,
+      delay: React.PropTypes.number,
     };
   }
 
@@ -29,7 +32,18 @@ export default class Loading extends React.Component {
       );
     }
 
-    return (
+    const maybeDelay = (children) => {
+      if (typeof this.props.delay === 'number') {
+        return (
+          <Delay wait={this.props.delay}>
+            {children}
+          </Delay>
+        );
+      }
+      return children;
+    }
+
+    return maybeDelay(
       <div className={[ 'loading' ].concat(extraClassNames).join(' ')}>
         {els}
       </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/component-loading",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A component that displays a very subtle loading indicator.",
   "author": "The Economist (http://economist.com)",
   "license": "ISC",
@@ -127,7 +127,8 @@
   },
   "dependencies": {
     "@economist/component-devpack": "^3.5.0",
-    "@economist/component-typography": "^1.4.3"
+    "@economist/component-typography": "^1.4.3",
+    "react-delay": "0.0.3"
   },
   "devDependencies": {
     "babel": "^5.8.23",

--- a/test/index.es6
+++ b/test/index.es6
@@ -2,6 +2,7 @@
 import Loading from '..';
 import TestUtils from 'react-addons-test-utils';
 import React from 'react';
+import Delay from 'react-delay';
 
 describe('Loading', () => {
   describe(`is a React component`, () => {
@@ -37,6 +38,15 @@ describe('Loading', () => {
       const loadingText = main.props.children[0];
 
       loadingText.props.className.should.equal('loading__overlay');
+    });
+    it(`can be delayed`, () => {
+      const shallowRenderer = TestUtils.createRenderer();
+      shallowRenderer.render(React.createElement(Loading, { delay: 101 }));
+      const main = shallowRenderer.getRenderOutput();
+      const delay = main.props.children;
+
+      main.type.should.equal(Delay);
+      main.props.wait.should.equal(101);
     });
   });
 });


### PR DESCRIPTION
The thing about spinners is that they look very web 2.0 if they just show up immediately.

The revamp is very big on optimistic rendering, whose the purpose is to show the actual layout and some data to the user before something comes around.

This is pretty important because a spinner tells the user "wait a sec", but we don't want to tell that at the same time we tell them "expect something here". Waiting until there's actually some waiting time fixes that signal mixup and signals to the user that there's some waiting to be done.

Using react-delay, which is pretty simple and very straightforward to code review.