### PR TITLE
Remove reference to old font name.

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,4 +1,3 @@
-@import "@economist/component-typography";
 
 :root {
   --loading-default-thickness: 0.6em;
@@ -8,7 +7,6 @@
 
 .loading {
   font-size: 1rem;
-  font-family: var(--fontfamily-serif);
   width: 100%;
   display: flex;
   flex-direction: column;

--- a/package.json
+++ b/package.json
@@ -127,7 +127,6 @@
   },
   "dependencies": {
     "@economist/component-devpack": "^3.5.0",
-    "@economist/component-typography": "^3.1.1",
     "react-delay": "0.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/component-loading",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A component that displays a very subtle loading indicator.",
   "author": "The Economist (http://economist.com)",
   "license": "ISC",


### PR DESCRIPTION
Found some references to the old font name ("FF Milo Serif Pro") in the website.

It is especially weird in component-loading, which doesn't have text.

This removes it.