### PR TITLE
WP-1425 - chore: update react-delay (0.0.4) and get rid of depr. warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,8 +101,9 @@
     ]
   },
   "dependencies": {
+    "prop-types": "^15.6.0",
     "react": "^0.14.8||^15.0.0",
-    "react-delay": "0.0.3"
+    "react-delay": "0.0.4"
   },
   "devDependencies": {
     "@economist/doc-pack": "^1.0.7",
@@ -118,8 +119,9 @@
     "browserify": "^13.0.1",
     "browserify-istanbul": "^2.0.0",
     "chai": "^3.5.0",
-    "chai-enzyme": "^0.4.2",
+    "chai-enzyme": "^0.5.2",
     "chai-spies": "^0.7.1",
+    "cheerio": "^0.22.0",
     "coveralls": "^2.11.9",
     "enzyme": "^2.2.0",
     "eslint": "^2.9.0",
@@ -152,6 +154,7 @@
     "postcss-url": "^5.1.2",
     "react-addons-test-utils": "^0.14.8||^15.0.0",
     "react-dom": "^0.14.8||^15.0.0",
+    "react-test-renderer": "^15.0.0",
     "semantic-release": "^4.3.5",
     "stylelint": "^6.3.3",
     "stylelint-config-strict": "^5.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,22 +1,8 @@
 import Delay from 'react-delay';
 import React from 'react';
+import PropTypes from 'prop-types';
 
 export default class Loading extends React.Component {
-
-  static get propTypes() {
-    return {
-      className: React.PropTypes.string,
-      overlay: React.PropTypes.bool,
-      loadingText: React.PropTypes.string,
-      delay: React.PropTypes.number,
-    };
-  }
-  static get defaultProps() {
-    return {
-      loadingText: 'the browser is loading new content',
-    };
-  }
-
   shouldComponentUpdate() {
     return false;
   }
@@ -55,3 +41,16 @@ export default class Loading extends React.Component {
     );
   }
 }
+
+if (process.env.NODE_ENV !== 'production') {
+  Loading.propTypes = {
+    className: PropTypes.string,
+    overlay: PropTypes.bool,
+    loadingText: PropTypes.string,
+    delay: PropTypes.number,
+  };
+}
+
+Loading.defaultProps = {
+  loadingText: 'the browser is loading new content',
+};


### PR DESCRIPTION
This is part of the [WP-1425](https://jira.economist.com/browse/WP-1425) - preparing the code base for migration to React 16.