### PR TITLE
WP-1492 prepare for react 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache:
   directories:
     - node_modules
 node_js:
-  - '4'
+  - '6'
   - stable
 after_success: >-
   travis-after-all && npm run semantic-release && npm run pages -- --repo

--- a/package.json
+++ b/package.json
@@ -102,8 +102,10 @@
   },
   "dependencies": {
     "prop-types": "^15.6.0",
-    "react": "^0.14.8||^15.0.0",
     "react-delay": "0.0.4"
+  },
+  "peerDependencies": {
+    "react": "^0.14.8||^15.0.0||^16.0.0"
   },
   "devDependencies": {
     "@economist/doc-pack": "^1.0.7",
@@ -119,11 +121,12 @@
     "browserify": "^13.0.1",
     "browserify-istanbul": "^2.0.0",
     "chai": "^3.5.0",
-    "chai-enzyme": "^0.5.2",
+    "chai-enzyme": "^1.0.0-beta.0",
     "chai-spies": "^0.7.1",
     "cheerio": "^0.22.0",
     "coveralls": "^2.11.9",
-    "enzyme": "^2.2.0",
+    "enzyme": "^3.0.0",
+    "enzyme-adapter-react-16": "^1.0.1",
     "eslint": "^2.9.0",
     "eslint-config-strict": "^8.5.1",
     "eslint-config-strict-react": "^8.0.1",
@@ -152,9 +155,9 @@
     "postcss-import": "^8.1.2",
     "postcss-reporter": "^1.3.3",
     "postcss-url": "^5.1.2",
-    "react-addons-test-utils": "^0.14.8||^15.0.0",
-    "react-dom": "^0.14.8||^15.0.0",
-    "react-test-renderer": "^15.0.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
+    "react-test-renderer": "^16.0.0",
     "semantic-release": "^4.3.5",
     "stylelint": "^6.3.3",
     "stylelint-config-strict": "^5.0.0",

--- a/test/index.js
+++ b/test/index.js
@@ -2,8 +2,11 @@ import 'babel-polyfill';
 import { mount, shallow } from 'enzyme';
 import Loading from '../src';
 import React from 'react';
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
 import chai from 'chai';
 import chaiEnzyme from 'chai-enzyme';
+Enzyme.configure({ adapter: new Adapter() });
 chai.use(chaiEnzyme()).should();
 describe('Loading', () => {
   describe('is a React component', () => {


### PR DESCRIPTION
A few notes from me:

- This component was using the `prop-types` package already, so just upgrading to React 16
- `enzyme` and `chai-enzyme` are used by the tests, so they have been upgraded